### PR TITLE
Formatting comments on exported functions to match Go Standards

### DIFF
--- a/google_apps.go
+++ b/google_apps.go
@@ -10,13 +10,13 @@ import (
 
 var store = sessions.NewCookieStore([]byte(""))
 
-//Identity receives the identity that's associated with the session
+//Identity receives the identity that's associated with the session.
 func Identity(r *http.Request) string {
 	session, _ := store.Get(r, "login")
 	return session.Values["id"].(string)
 }
 
-//IsAuthenticated returns if is the request authenticated
+//IsAuthenticated returns if is the request authenticated.
 func IsAuthenticated(r *http.Request) bool {
 	session, _ := store.Get(r, "login")
 	return session.Values["id"] != nil

--- a/google_apps.go
+++ b/google_apps.go
@@ -10,19 +10,19 @@ import (
 
 var store = sessions.NewCookieStore([]byte(""))
 
-//Identity - Receive the identity that's associated with the session
+//Identity receives the identity that's associated with the session
 func Identity(r *http.Request) string {
 	session, _ := store.Get(r, "login")
 	return session.Values["id"].(string)
 }
 
-//IsAuthenticated - Is the request authenticated?
+//IsAuthenticated returns if is the request authenticated
 func IsAuthenticated(r *http.Request) bool {
 	session, _ := store.Get(r, "login")
 	return session.Values["id"] != nil
 }
 
-//ProtectionHandler - GoogleAppsHandler "middleware".
+//ProtectionHandler is a  GoogleAppsHandler "middleware".
 // Wraps the passed HandlerFunc with google apps authentication
 //
 // Example:

--- a/google_apps.go
+++ b/google_apps.go
@@ -10,19 +10,19 @@ import (
 
 var store = sessions.NewCookieStore([]byte(""))
 
-// Receive the identity that's associated with the session
+//Identity - Receive the identity that's associated with the session
 func Identity(r *http.Request) string {
 	session, _ := store.Get(r, "login")
 	return session.Values["id"].(string)
 }
 
-// Is the request authenticated?
+//IsAuthenticated - Is the request authenticated?
 func IsAuthenticated(r *http.Request) bool {
 	session, _ := store.Get(r, "login")
 	return session.Values["id"] != nil
 }
 
-// GoogleAppsHandler "middleware".
+//ProtectionHandler - GoogleAppsHandler "middleware".
 // Wraps the passed HandlerFunc with google apps authentication
 //
 // Example:


### PR DESCRIPTION
Following GoLang documentation indicates that exported functions should have a full sentences comments who begin with the name of the function and end in a period. 

https://github.com/golang/go/wiki/CodeReviewComments#comment-sentences